### PR TITLE
Fix offset out of bounds (offset=n, max_matches=1000)

### DIFF
--- a/src/SphinxEngine.php
+++ b/src/SphinxEngine.php
@@ -103,7 +103,9 @@ class SphinxEngine extends AbstractEngine
      */
     public function paginate(Builder $builder, $perPage, $page)
     {
-        return $this->performSearch($builder)->limit($perPage * ($page - 1), $perPage)
+        return $this->performSearch($builder)
+            ->limit($perPage * ($page - 1), $perPage)
+            ->option('max_matches', $perPage * $page)
             ->execute();
     }
 


### PR DESCRIPTION
Fix error caused by trying to request more results than allowed by max_matches, which is 1000 by default